### PR TITLE
fix(index): don't return undefined and always return string

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,8 +36,8 @@ describe('YouTubeVideoId', function () {
   });
 
   describe('string', () => {
-    it('returns string', function () {
-      expect(YouTubeVideoId('qwgNv27366Q')).toBe('qwgNv27366Q');
+    it.each(['', 'qwgNv27366Q'])('returns %p', function (value) {
+      expect(YouTubeVideoId(value)).toBe(value);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,14 +16,14 @@ const regex =
  * @param url - The URL or string.
  * @returns - The video ID.
  */
-export default function YouTubeVideoId(url: string) {
+export default function YouTubeVideoId(url: string): string {
   if (typeof url !== 'string') {
     throw new TypeError('First argument must be a string');
   }
 
   const match = url.match(regex);
 
-  if (match && match.length > 1) {
+  if (match?.length && match[2]) {
     return match[2];
   }
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(index): don't return undefined and always return string

## What is the current behavior?

Return type is `string` or `undefined`

## What is the new behavior?

Return type is `string`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation